### PR TITLE
Updated composer.json PHP version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "rsc/betterblockhints",
     "description": "Better template block hints for designing Magento2 templates and modifying layout XML",
     "require": {
-        "php": "~5.6.5|7.0.2|7.0.4|~7.0.6"
+        "php": "~5.6.5|~7.0"
     },
     "type": "magento2-module",
     "version": "0.1.0",


### PR DESCRIPTION
BetterBlockHints could not be installed on a system with PHP  greater than 7.0.
This changes the required PHP version to `~5.6.5|~7.0`.

Tested with Magento OpenSource 2.2.3 and PHP 7.1.14.